### PR TITLE
fix: add shebang in the entry point of the library

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import OpenAPI from '@readme/openapi-parser'
 import type { OpenAPIV3_1 } from 'openapi-types'
 import { format } from 'prettier'


### PR DESCRIPTION
As I said in #2, it looks like there is an issue when running `yarn run o2ts` :
```
❯ yarn run o2ts openapi/document-upload-api.yaml
yarn run v1.22.19
$ /Users/mishaa/yago/seraphinWeb/node_modules/.bin/o2ts openapi/document-upload-api.yaml
/Users/mishaa/yago/seraphinWeb/node_modules/.bin/o2ts: line 1: import: command not found
/Users/mishaa/yago/seraphinWeb/node_modules/.bin/o2ts: line 2: import: command not found
/Users/mishaa/yago/seraphinWeb/node_modules/.bin/o2ts: line 3: import: command not found
/Users/mishaa/yago/seraphinWeb/node_modules/.bin/o2ts: line 4: import: command not found
/Users/mishaa/yago/seraphinWeb/node_modules/.bin/o2ts: line 5: try: command not found
/Users/mishaa/yago/seraphinWeb/node_modules/.bin/o2ts: line 6: syntax error near unexpected token `('
/Users/mishaa/yago/seraphinWeb/node_modules/.bin/o2ts: line 6: `    const args = process.argv.slice(2);'
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

This happens because the file is not interpreted as JavaScript file and are not executed by Node.
Adding [Shebang](https://fr.wikipedia.org/wiki/Shebang) fix the issue. 