### PR TITLE
fix: handle all success response codes

### DIFF
--- a/src/SchemaParser.ts
+++ b/src/SchemaParser.ts
@@ -121,7 +121,9 @@ export type APIResponse<
   }
 
   private responseToType (responses: Responses): NodeType {
-    let response = responses?.['200']
+    let response = responses 
+      ? Object.entries(responses).filter(e => e[0][0] === '2').map(e => e[1])[0]
+      : undefined;
     if (!response) {
       return new SimpleType('null')
     }


### PR DESCRIPTION
With the current version, when an API call send an other status code than 200, the generated result is null.

With this PR, the first 2XX code found will be used to compute the result.